### PR TITLE
Remove broken hooks.

### DIFF
--- a/install-hooks.sh
+++ b/install-hooks.sh
@@ -7,7 +7,7 @@ fi
 
 SCRIPT_DIR=$(cd "${0%/*}" && pwd)
 
-SCRIPTS=(pre-commit post-checkout post-merge)
+SCRIPTS=(pre-commit)
 
 for SCRIPT in "${SCRIPTS[@]}"; do
     ln -snf "$SCRIPT_DIR/$SCRIPT" ".git/hooks/$SCRIPT"

--- a/post-checkout
+++ b/post-checkout
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# Remove empty assets directory
-find Assets -depth -type d -empty -delete

--- a/post-merge
+++ b/post-merge
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# Remove empty assets directory
-find Assets -depth -type d -empty -delete


### PR DESCRIPTION
This removes the broken hooks for `post-checkout` and `post-merge` that fail on Windows. Only the `pre-commit` hook is installed by default now.
